### PR TITLE
Disable Cypress record key after-push flow

### DIFF
--- a/.github/workflows/github-actions-after-push.yml
+++ b/.github/workflows/github-actions-after-push.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Cypress run
-        run: npx cypress run --record --key acf5a95a-f5fe-4d53-818a-a6afa18e512c
+        run: npx cypress run


### PR DESCRIPTION
Disable Cypress record key after-push (Github-actions) flow