### PR TITLE
PR-0502: Update node version for GitHub Actions

### DIFF
--- a/.github/workflows/github-actions-after-push.yml
+++ b/.github/workflows/github-actions-after-push.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-           node-version: '14'
+           node-version: '18'
       - name: Install dependencies
         run: npm install
       - name: Cypress run

--- a/.github/workflows/github-actions-manually.yml
+++ b/.github/workflows/github-actions-manually.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-           node-version: '14'
+           node-version: '18'
       - name: Install dependencies
         run: npm install
       - name: Cypress run


### PR DESCRIPTION
## Summary
This test framework is deprecated. For a long time, no one followed him and did not take any actions to improve the work. During this time, some functionality became obsolete, namely the work of CI/CD based on GitHub. We used to use node version 14 but it's been almost 2 years and that version is outdated so after discussion we decided to upgrade it to 18

## Work Plan

- Change the node version from 14 to 18
- Check that the new version does not confuse the operation of the program